### PR TITLE
Fix FRONTEND_URL fetching issue and verification email redirection route

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
   // get config service after app is created
   const configService = app.get(ConfigService);
   const frontendUrl = configService.get<string>('FRONTEND_URL');
+  console.log('FRONTEND_URL:', frontendUrl);
 
   app.enableCors({
     origin: [frontendUrl, 'https://your-frontend.com'], // allowed origins

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -34,8 +34,8 @@ export class AuthService {
       { expiresIn: '24h' },
     );
     
-    const baseUrl = this.configService.get('BASE_URL');
-    const verifyUrl = `${baseUrl}/auth/verify-email?token=${token}`;
+    const baseUrl = this.configService.get('FRONTEND_URL');
+    const verifyUrl = `${baseUrl}/verify-email?token=${token}`;
     
     await sendVerificationEmail(email, verifyUrl);
     return { email, message: 'Verification link sent to email' };
@@ -128,8 +128,8 @@ export class AuthService {
       
         const token = this.jwtService.sign({ email }, { expiresIn: '24h' });
         
-        const baseUrl = this.configService.get('BASE_URL');
-        const verifyUrl = `${baseUrl}/auth/verify-email?token=${token}`;
+        const baseUrl = this.configService.get('FRONTEND_URL');
+        const verifyUrl = `${baseUrl}/verify-email?token=${token}`;
       
         await sendVerificationEmail(email, verifyUrl);
         return { email, message: 'Verification email resent' };
@@ -140,7 +140,7 @@ export class AuthService {
         if (!user) throw new BadRequestException('User not found');
       
         const token = this.jwtService.sign({ email }, { expiresIn: '15m' });
-        const baseUrl = this.configService.get('BASE_URL');
+        const baseUrl = this.configService.get('FRONTEND_URL');
         const resetUrl = `${baseUrl}/auth/reset-password?token=${token}`;
       
         await sendPasswordResetEmail(email, resetUrl); 


### PR DESCRIPTION
Set FRONTEND_URL in the .env file and changed BASE_URL to FRONTEND_URL throughout the auth.service.ts file so the frontend url can be properly retrieved.
Also changed the verifyUrl variable to
`${baseUrl}/verify-email?token=${token}` from
`${baseUrl}/auth/verify-email?token=${token}`